### PR TITLE
Quicker way to derive inverse of m4 derived matrix

### DIFF
--- a/R/ed_laplace_ofv.R
+++ b/R/ed_laplace_ofv.R
@@ -478,8 +478,8 @@ calc_k <- function(alpha, model_switch,groupsize,ni,xtoptn,xoptn,aoptn,bpopdescr
   fim <- retargs$ret
   
   det_fim <- det(fim)
-  if(det_fim<0){
-    warning("Determinant of the FIM is negative")
+  if(det_fim<.Machine$double.eps){
+    warning("Determinant of the FIM is not positive")
     if(return_gradient) return(list(k=NaN,grad_k = NaN))
     return(c(k=NaN))
   }

--- a/R/inv.R
+++ b/R/inv.R
@@ -6,7 +6,7 @@
 #' Function computes the inverse of a matrix.
 #'
 #' @param mat A matrix
-#' @param method Which method to use. 1 is cholesky, 2 is using solve and 3 is the Moore-Penrose generalized inverse.
+#' @param method Which method to use (now deprecated).
 #' @param tol The tolerance at wich we should identify a sigular value as zero.
 #'
 #' @return The inverse matrix
@@ -14,14 +14,18 @@
 #' @keywords internal
 
 inv<- function(mat,method=1,tol = .Machine$double.eps){
-  if(method==1) return(chol2inv(chol(mat)))
-  if(method==2) return(solve(mat))
-  if(method==3){ # Moore-Penrose generalized inverse
-    Xsvd <- svd(mat)
-    #if (is.complex(mat)) Xsvd$u <- Conj(Xsvd$u)
-    Positive <- Xsvd$d > max(tol * max(dim(mat))*max(Xsvd$d), 0)
-    if (all(Positive)) return(Xsvd$v %*% (1/Xsvd$d * t(Xsvd$u)))
-    else if (!any(Positive)) return(array(0, dim(mat)[2L:1L]))
-    else return(Xsvd$v[, Positive, drop = FALSE] %*% ((1/Xsvd$d[Positive]) * t(Xsvd$u[, Positive, drop = FALSE])))
-  }
+  # Cholesky Decomposition costs approx. 50% more than calculating the determinant
+  # So instead of testing the determinant we can immediately test the decomposition
+  invvar <- try(chol2inv(chol(mat)), silent = TRUE)
+
+  # If the result is numeric, it was successful
+  if (is.numeric(invvar)) return(invvar)
+
+  # Otherwise calculate the Moore-Penrose generalized inverse
+  Xsvd <- svd(mat)
+  #if (is.complex(mat)) Xsvd$u <- Conj(Xsvd$u)
+  Positive <- Xsvd$d > max(tol * max(dim(mat))*max(Xsvd$d), 0)
+  if (all(Positive)) return(Xsvd$v %*% (1/Xsvd$d * t(Xsvd$u)))
+  else if (!any(Positive)) return(array(0, dim(mat)[2L:1L]))
+  else return(Xsvd$v[, Positive, drop = FALSE] %*% ((1/Xsvd$d[Positive]) * t(Xsvd$u[, Positive, drop = FALSE])))
 }

--- a/R/mf3.R
+++ b/R/mf3.R
@@ -76,9 +76,11 @@ mf3 <- function(model_switch,xt,x,a,bpop,d,sigma,docc,poped.db){
     v_tmp <- returnArgs[[1]]
     poped.db <- returnArgs[[2]]
     if((matrix_any(v_tmp)!=0) ){#If there are some non-zero elements to v_tmp
-      f2[1:n,1:n]=inv(v_tmp,method=3) # pseudoinverse
-      tmp_m4=m4(v_tmp,n)
-      f2[(n+1):(n+n*n),(n+1):(n+n*n)]=inv(tmp_m4,method=3) # pseudoinverse
+      v_tmp_inv = inv(v_tmp)
+      f2[1:n,1:n] = v_tmp_inv
+      
+      tmp_m4_inv=0.25*m4(v_tmp_inv,n)
+      f2[(n+1):(n+n*n),(n+1):(n+n*n)] = tmp_m4_inv
     }
     if((all(f2==0))){
       ret = ret+t(f1)%*%f1


### PR DESCRIPTION
Instead of creating the huge m4 matrix from smaller blocks (v_tmp) and then inverting it, it is faster to invert the small block matrix (inv(v_tmp)) and use m4 to create the inverted matrix.
inv(m4(v_tmp,n)) == 0.25*m4(inv(v_tmp),n)
