### PR TITLE
RSE needs to include prior_fim

### DIFF
--- a/R/get_cv.R
+++ b/R/get_cv.R
@@ -98,6 +98,11 @@ get_rse <- function (fmf, poped.db,
       eval(parse(text=paste(capture.output(default_args[[i]]),"<-",i)))
     }
   }
+
+  ## if prior is given in poped.db then add it to the given fim
+  if((!isempty(poped.db$settings$prior_fim) && all(size(poped.db$settings$prior_fim)==size(fmf)))){
+    fmf = fmf + poped.db$settings$prior_fim
+  }
   
   inv_fim <- tryCatch({
     inv(fmf,...)

--- a/tests/testthat/examples_fcn_doc/examples_evaluate.fim.R
+++ b/tests/testthat/examples_fcn_doc/examples_evaluate.fim.R
@@ -69,3 +69,7 @@ FIM.7
 det(FIM.7)
 get_rse(FIM.7,poped.db,fim.calc.type=7)
 
+## evaluate FIM and rse with prior FIM.1
+poped.db.prior = create.poped.database(poped.db, prior_fim = FIM.1)
+FIM.1.prior <- evaluate.fim(poped.db.prior)
+FIM.1.prior

--- a/tests/testthat/test_evaluate.fim.R
+++ b/tests/testthat/test_evaluate.fim.R
@@ -9,7 +9,7 @@ test_that("RSE from evaluate.fim", {
   comp.red.1 <- get_rse(FIM.1,poped.db)
   comp.red.4 <- get_rse(FIM.4,poped.db,fim.calc.type=4)
   comp.full.0 <- get_rse(FIM.0,poped.db)
-  
+  comp.red.1.prior <- get_rse(FIM.1.prior, poped.db.prior)
   
   for(i in 1:length(expected.reduced)){
     expect_that(round(comp.red.1[[i]],digits=1), equals(expected.reduced[i], 
@@ -23,6 +23,8 @@ test_that("RSE from evaluate.fim", {
     expect_that(round(comp.red.4[[i]],digits=1), equals(expected.reduced[i], 
                                         tolerance = 0.01, scale = expected.reduced[i]))
   }
+  
+  expect_true(all.equal(comp.red.1/sqrt(2), comp.red.1.prior))
   
 })
 


### PR DESCRIPTION
If a prior_fim is given in the poped.db it is expected that it is considered in the calculation of the relative standard error. (This is the case for the ovf, so the code was copied from there.)